### PR TITLE
Fix examples so nodemon uses babel instead of node-jsx to transform

### DIFF
--- a/example/server.js
+++ b/example/server.js
@@ -1,4 +1,4 @@
-require('node-jsx').install({extension: '.jsx'});
+require("babel/register");
 
 var React = require('react'), 
   express = require('express'),

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build:css": "node-sass src/PictureShow.scss lib/PictureShow.css",
     "build:js": "babel ./src --out-dir ./lib",
     "build": "npm run build:js && npm run build:css",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "babel-node": "babel-node --stage 0 --ignore='foo|bar|baz'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Examples work when using gulp nodemon now.
